### PR TITLE
Align readme.txt compatibility headers with WordPress 7.0

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Blocks for GitHub ===
 Contributors: dlocc
 Tags: github, gutenberg blocks, github profile, repository display, developer tools
-Requires at least: 6.0
-Tested up to: 6.7
+Requires at least: 6.5
+Tested up to: 7.0
 Requires PHP: 8.0
 Stable tag: 1.0.0
 License: GPL-2.0-or-later


### PR DESCRIPTION
## Summary

- Aligns `readme.txt` **Requires at least** with the plugin header and activation check (6.5 instead of 6.0).
- Sets **Tested up to** to `7.0`, the wordpress.org convention for the 7.0.x branch (major.minor only; does not claim 7.1 compatibility).

## Context

The directory readme still showed WP 6.7 as the latest tested version, while `blocks-for-github.php` already requires 6.5+. This is a metadata-only change; no code changes.

Closes #12

## Test plan

- [ ] Confirm readme headers parse cleanly for the plugin directory
- [ ] Smoke test block inserter and profile/repository blocks on WordPress 7.0.x
