### PR TITLE
Format profile repo pill counts with compact GitHub-style numbers

### DIFF
--- a/src/Block.php
+++ b/src/Block.php
@@ -14,6 +14,48 @@ class Block {
         $this->attributes = $attributes;
     }
 
+    /**
+     * Format a count for compact badge/pill display (GitHub-style).
+     *
+     * Uses locale-aware grouping under 1,000, one decimal k/M between 1,000 and 99,999,
+     * and whole k/M from 100,000 upward so wide counts fit small pills.
+     */
+    protected function format_count( int $count ): string {
+        if ( $count >= 1_000_000 ) {
+            if ( $count >= 100_000_000 ) {
+                return (string) (int) round( $count / 1_000_000 ) . 'M';
+            }
+
+            return $this->format_compact_unit( $count, 1_000_000, 'M' );
+        }
+
+        if ( $count >= 100_000 ) {
+            return (string) (int) round( $count / 1_000 ) . 'k';
+        }
+
+        if ( $count >= 1_000 ) {
+            return $this->format_compact_unit( $count, 1_000, 'k' );
+        }
+
+        return number_format_i18n( $count );
+    }
+
+    /**
+     * @param int    $count  Raw count value.
+     * @param int    $unit   Divisor for the compact unit (1_000 or 1_000_000).
+     * @param string $suffix Compact suffix (`k` or `M`).
+     */
+    protected function format_compact_unit( int $count, int $unit, string $suffix ): string {
+        $value = round( $count / $unit, 1 );
+        $formatted = number_format( $value, 1, '.', '' );
+
+        if ( str_ends_with( $formatted, '.0' ) ) {
+            $formatted = substr( $formatted, 0, -2 );
+        }
+
+        return $formatted . $suffix;
+    }
+
     protected function fetchData( string $url, string $keySuffix = '' ) {
         $key  = "blocks_for_github_$keySuffix";
         $data = get_transient( $key );
@@ -318,11 +360,11 @@ class Block {
                                         <span
                                             class="bfg-top-repo-pill bfg-top-repo-pill--blue"><?php echo file_get_contents(
                                                 BLOCKS_FOR_GITHUB_DIR . '/assets/images/fork.svg'
-                                            ); ?><?php esc_html_e( $repo->forks ); ?></span>
+                                            ); ?><?php echo esc_html( $this->format_count( (int) $repo->forks ) ); ?></span>
                                         <span
                                             class="bfg-top-repo-pill bfg-top-repo-pill--gold"><?php echo file_get_contents(
                                                 BLOCKS_FOR_GITHUB_DIR . '/assets/images/star.svg'
-                                            ); ?><?php esc_html_e( $repo->stargazers_count ); ?></span>
+                                            ); ?><?php echo esc_html( $this->format_count( (int) $repo->stargazers_count ) ); ?></span>
                                     </div>
                                 </div>
 


### PR DESCRIPTION
## Summary

Fixes #3 by formatting fork and star counts on profile repo pills.

- Adds a shared `format_count()` helper for badge-style numbers.
- Counts under 1,000 use `number_format_i18n()` (locale-aware grouping).
- Counts from 1k upward use GitHub-style compact values (`1.1k`, `13.9k`, `158k`) so large profiles like Octocat stay readable inside the pills.

## Why compact for pills only

The follow button and repo meta row already used full grouped numbers, which works in wider space. The profile repo pills are narrow, so matching GitHub's abbreviated style there felt like the right tradeoff.

## Before and After

| Before | After |
|:------:|:-----:|
| <img width="400" alt="Before: full numbers in profile pills" src="https://github.com/user-attachments/assets/60588705-5b6e-459c-8ec7-787f71ca053b" /> | <img width="400" alt="After: compact k notation in pills" src="https://github.com/user-attachments/assets/192457e8-9f99-4afd-87cf-a798aa8cfeb7" /> |

## Test plan

- [ ] Insert a profile block with username `Octocat` and confirm fork/star pills show compact values (e.g. `158k`, `13.9k`) instead of raw digits.
- [ ] Confirm smaller repos still show plain numbers (e.g. `580`).
- [ ] Spot-check a repository block to ensure unrelated counts are unchanged.
