### PR TITLE
Add optional custom avatar to repository block

### DIFF
--- a/block.json
+++ b/block.json
@@ -30,6 +30,14 @@
             "type": "string",
             "default": ""
         },
+        "customAvatarMediaId": {
+            "type": "integer",
+            "default": 0
+        },
+        "customAvatarMediaUrl": {
+            "type": "string",
+            "default": ""
+        },
         "customTitle": {
             "type": "string",
             "default": ""

--- a/src/Block.php
+++ b/src/Block.php
@@ -14,6 +14,52 @@ class Block {
         $this->attributes = $attributes;
     }
 
+    /**
+     * Resolve the repository block avatar URL (custom image or GitHub owner avatar).
+     *
+     * Falls back to the repo owner's GitHub avatar for both user- and org-owned repos.
+     */
+    protected function get_repo_avatar_url( object $data ): string {
+        $media_id = (int) ( $this->attributes['customAvatarMediaId'] ?? 0 );
+
+        if ( $media_id > 0 && wp_attachment_is_image( $media_id ) ) {
+            $custom_url = wp_get_attachment_image_url( $media_id, 'medium' );
+
+            if ( is_string( $custom_url ) && $custom_url !== '' ) {
+                return $custom_url;
+            }
+        }
+
+        return $data->owner->avatar_url;
+    }
+
+    /**
+     * Alt text for the repository block avatar image.
+     */
+    protected function get_repo_avatar_alt( object $data ): string {
+        $media_id = (int) ( $this->attributes['customAvatarMediaId'] ?? 0 );
+
+        if ( $media_id > 0 ) {
+            $attachment_alt = get_post_meta( $media_id, '_wp_attachment_image_alt', true );
+
+            if ( is_string( $attachment_alt ) && $attachment_alt !== '' ) {
+                return $attachment_alt;
+            }
+        }
+
+        $owner_type = isset( $data->owner->type ) && $data->owner->type === 'Organization'
+            ? __( 'organization', 'blocks-for-github' )
+            : __( 'owner', 'blocks-for-github' );
+
+        return sprintf(
+            /* translators: 1: repository name, 2: owner or organization label, 3: GitHub login */
+            __( '%1$s %2$s avatar (%3$s)', 'blocks-for-github' ),
+            $data->name,
+            $owner_type,
+            $data->owner->login
+        );
+    }
+
     protected function fetchData( string $url, string $keySuffix = '' ) {
         $key  = "blocks_for_github_$keySuffix";
         $data = get_transient( $key );
@@ -117,12 +163,15 @@ class Block {
      * @throws Exception
      */
     public function renderRepo( $data ) {
+        $avatar_url = $this->get_repo_avatar_url( $data );
+        $avatar_alt = $this->get_repo_avatar_alt( $data );
+
         ob_start(); ?>
         <div class="bfg-wrap bfg-repo" id="bfg-wrap-<?php esc_html_e( $data->id ); ?>">
             <div class="bfg-repo-header bfg-grid-container">
                 <div class="bfg-repo-avatar-wrap">
-                    <img class="bfg-avatar" src="<?php esc_html_e( $data->owner->avatar_url ); ?>"
-                         alt="<?php esc_html_e( $data->name ); ?>" />
+                    <img class="bfg-avatar" src="<?php echo esc_url( $avatar_url ); ?>"
+                         alt="<?php echo esc_attr( $avatar_alt ); ?>" />
                 </div>
                 <div class="bfg-repo-content">
                     <div class="bfg-repo-name-wrap">

--- a/src/edit.js
+++ b/src/edit.js
@@ -43,6 +43,8 @@ export default function Edit({attributes, setAttributes}) {
 		showTwitter,
 		mediaId,
 		mediaUrl,
+		customAvatarMediaId,
+		customAvatarMediaUrl,
 		preview,
 	} = attributes;
 
@@ -79,11 +81,32 @@ export default function Edit({attributes, setAttributes}) {
 		});
 	};
 
+	const removeCustomAvatar = () => {
+		setAttributes({
+			customAvatarMediaId: 0,
+			customAvatarMediaUrl: '',
+		});
+	};
+
+	const onSelectCustomAvatar = (media) => {
+		setAttributes({
+			customAvatarMediaId: media.id,
+			customAvatarMediaUrl: media.url,
+		});
+	};
+
 	const media = useSelect(
 		(select) => {
 			return select('core').getMedia(mediaId);
 		},
-		[onSelectMedia]
+		[mediaId]
+	);
+
+	const customAvatarMedia = useSelect(
+		(select) => {
+			return select('core').getMedia(customAvatarMediaId);
+		},
+		[customAvatarMediaId]
 	);
 
 	return (
@@ -133,6 +156,76 @@ export default function Edit({attributes, setAttributes}) {
 										setAttributes({customTitle: newCustomTitle});
 									}}
 								/>
+							</PanelRow>
+							<PanelRow>
+								<div className="bfg-media-uploader">
+									<p className={'bfg-label'}>
+										<label>{__('Custom avatar', 'stellarpay')}</label>
+									</p>
+									<MediaUploadCheck>
+										<MediaUpload
+											onSelect={onSelectCustomAvatar}
+											value={customAvatarMediaId}
+											allowedTypes={['image']}
+											render={({open}) => (
+												<Button
+													className={
+														customAvatarMediaId === 0
+															? 'editor-post-featured-image__toggle'
+															: 'editor-post-featured-image__preview'
+													}
+													onClick={open}
+												>
+													{customAvatarMediaId === 0 &&
+														__('Choose an image', 'stellarpay')}
+													{customAvatarMedia !== undefined && (
+														<ResponsiveWrapper
+															naturalWidth={customAvatarMedia.media_details.width}
+															naturalHeight={customAvatarMedia.media_details.height}
+														>
+															<img src={customAvatarMedia.source_url} alt="" />
+														</ResponsiveWrapper>
+													)}
+												</Button>
+											)}
+										/>
+									</MediaUploadCheck>
+									<div className="bfg-media-btns">
+										{customAvatarMediaId !== 0 && (
+											<MediaUploadCheck>
+												<MediaUpload
+													title={__('Replace image', 'stellarpay')}
+													value={customAvatarMediaId}
+													onSelect={onSelectCustomAvatar}
+													allowedTypes={['image']}
+													render={({open}) => (
+														<Button
+															onClick={open}
+															isSmall
+															variant="secondary"
+															className={'bfg-replace-image-btn'}
+														>
+															{__('Replace image', 'stellarpay')}
+														</Button>
+													)}
+												/>
+											</MediaUploadCheck>
+										)}
+										{customAvatarMediaId !== 0 && (
+											<MediaUploadCheck>
+												<Button onClick={removeCustomAvatar} isSmall variant="secondary">
+													{__('Remove image', 'stellarpay')}
+												</Button>
+											</MediaUploadCheck>
+										)}
+									</div>
+									<p className={'bfg-help-text'}>
+										{__(
+											'Optional image for this repo block. When empty, the GitHub owner or organization avatar is used.',
+											'stellarpay'
+										)}
+									</p>
+								</div>
 							</PanelRow>
 							<PanelRow>
 								<CheckboxControl
@@ -340,6 +433,8 @@ export default function Edit({attributes, setAttributes}) {
 							repoUrl: attributes.repoUrl,
 							mediaId: attributes.mediaId,
 							mediaUrl: attributes.mediaUrl,
+							customAvatarMediaId: attributes.customAvatarMediaId,
+							customAvatarMediaUrl: attributes.customAvatarMediaUrl,
 							showTags: attributes.showTags,
 							showForks: attributes.showForks,
 							showSubscribers: attributes.showSubscribers,


### PR DESCRIPTION
## Summary

Fixes #4 by adding an optional **Custom avatar** control to the repository block.

- New block attributes: `customAvatarMediaId` / `customAvatarMediaUrl` (separate from the profile header image fields).
- Repository sidebar uses the same media picker pattern as the profile block.
- Server render uses the custom attachment when set; otherwise falls back to the GitHub repo owner's avatar (user or organization).

## Approach

Profile and repository blocks already shared one block type but used different image needs, so custom avatar gets its own attributes instead of reusing `mediaId`. That avoids carrying a profile header photo over when switching block modes.

Org-owned repos need no special API path: GitHub returns `owner.avatar_url` for both users and organizations, and the override simply replaces that default when present.

Closes #4

## Test plan

- [ ] Insert a repository block for a personal repo; confirm default owner avatar shows.
- [ ] Set a custom avatar; confirm it replaces the GitHub image in editor and front end.
- [ ] Remove the custom avatar; confirm GitHub default returns.
- [ ] Repeat with an organization-owned repo (e.g. `WordPress/gutenberg`) and confirm fallback uses the org logo until overridden.
